### PR TITLE
limit chat sessions to 1 per user

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.requests import Request
 from fastapi.middleware.cors import CORSMiddleware
-from ollama import ChatGPTAssistant, SessionLimitExceeded, get_time_millis
+from ollama import ChatGPTAssistant, SessionLimitExceeded, SessionAlreadyExists, get_time_millis
 from models import ChatSession, ChatRecord
 from dotenv import load_dotenv
 from sqlmodel import create_engine, SQLModel, Session, select, and_
@@ -62,6 +62,8 @@ async def _generate_response(req: Request):
         model = ChatGPTAssistant(metrics=metrics, user_email=user_email, session_id=session_id, pg_engine=pg_engine, openai_api_key=OPENAI_API_KEY)
     except SessionLimitExceeded:
         return { "success": False, "error": "You can only have one session running at a time." }
+    except SessionAlreadyExists:
+        return { "success": False, "error": "This session already exists and is owned by another user." }
 
     response = {}
 

--- a/ollama.py
+++ b/ollama.py
@@ -46,7 +46,7 @@ class LLMAssistant:
                 session.add(chat_record)
                 session.commit()
             else:
-                chat_session = session.exec(select(ChatSession).where(ChatSession.id == self.session_id)).first()
+                chat_session = session.exec(select(ChatSession).where(and_(ChatSession.id == self.session_id, ChatSession.user_email == self.user_email))).first()
                 if chat_session is not None and chat_session.has_ended:
                     if not self.has_existing_sessions():
                         chat_session.has_ended = False

--- a/ollama.py
+++ b/ollama.py
@@ -24,7 +24,7 @@ class LLMAssistant:
         self.pg_engine = pg_engine
 
         with Session(self.pg_engine) as session:
-            chat_session = session.exec(select(ChatSession).where(ChatSession.id == self.session_id)).first()
+            chat_session = session.exec(select(ChatSession).where(and_(ChatSession.id == self.session_id, ChatSession.user_email == self.user_email))).first()
             if chat_session is None:
                 if self.has_existing_sessions(): raise SessionLimitExceeded
 
@@ -46,8 +46,7 @@ class LLMAssistant:
                 session.add(chat_record)
                 session.commit()
             else:
-                chat_session = session.exec(select(ChatSession).where(and_(ChatSession.id == self.session_id, ChatSession.user_email == self.user_email))).first()
-                if chat_session is not None and chat_session.has_ended:
+                if chat_session.has_ended:
                     if not self.has_existing_sessions():
                         chat_session.has_ended = False
 


### PR DESCRIPTION
addresses #12 

previously users will be able to run more than a single chat session at a time.
with this change, users will get an error when they attempt to run more than a single session at a time